### PR TITLE
New wdl for ACE, adding readme file

### DIFF
--- a/ACE.wdl
+++ b/ACE.wdl
@@ -24,19 +24,6 @@ parameter_meta {
   reference: "Name and version of reference genome"
 }
 
-meta {
-  author: "Gavin Peng"
-  email: "gpengv@oicr.on.ca"
-  description: "ACE, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data"
-  dependencies: [
-      {
-        name: "ace/1.20.0",
-        url: "https://github.com/tgac-vumc/ACE"
-      }
-    ]
-
-}
-
 output {
   File SummaryError100k2N = runACE.SummaryError100k2N 
   File SummaryError100k4N = runACE.SummaryError100k4N 
@@ -58,7 +45,40 @@ output {
   File SampleFolder100k4N = runACE.SampleFolder100k2N
   File SampleFolder1000k2N = runACE.SampleFolder1000k2N
   File SampleFolder100044N = runACE.SampleFolder1000k4N
+}
 
+meta {
+  author: "Gavin Peng"
+  email: "gpeng@oicr.on.ca"
+  description: "ACE, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data"
+  dependencies: [
+      {
+        name: "ace/1.20.0",
+        url: "https://github.com/tgac-vumc/ACE"
+      }
+    ]
+  output_meta: {
+  SummaryError100k2N: "Error lists of all the models of 100k binsize and 2N ploidy",
+  SummaryError100k4N: "Error lists of all the models of 100k binsize and 4N ploidy",
+  SummaryLikelyfits100k2N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy",
+  SummaryLikelyfits100k4N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy",
+  SummaryError1000k2N: "Error lists of all the models of 1000k binsize and 2N ploidy",
+  SummaryError1000k4N: "Error lists of all the models of 100k binsize and 4N ploidy",
+  SummaryLikelyfits1000k2N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 2N ploidy",
+  SummaryLikelyfits1000k4N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 4N ploidy",
+  Fitpicker100k2N: "Tab-delimited file used during selection of most likely models. For 100k binsize and 2N ploidy",
+  Fitpicker100k4N: "Tab-delimited file used during selection of most likely models. For 100k binsize and 4N ploidy",
+  Fitpicker1000k2N: "Tab-delimited file used during selection of most likely models. For 1000k binsize and 2N ploidy",
+  Fitpicker1000k4N: "Tab-delimited file used during selection of most likely models. For 1000k binsize and 4N ploidy",
+  Likelyfits100k2N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 2N ploidy",
+  Likelyfits100k4N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 4N ploidy",
+  Likelyfits1000k2N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 2N ploidy",
+  Likelyfits1000k4N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 4N ploidy",
+  SampleFolder100k2N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 2N ploidy",
+  SampleFolder100k4N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 4N ploidy",
+  SampleFolder1000k2N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 2N ploidy",
+  SampleFolder100044N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 4N ploidy"
+  }
 }
 
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+# ACE
+
+ACE, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data
+
+## Overview
+
+## Dependencies
+
+* [ace 1.20.0](https://github.com/tgac-vumc/ACE)
+
+
+## Usage
+
+### Cromwell
+```
+java -jar cromwell.jar run ACE.wdl --inputs inputs.json
+```
+
+### Inputs
+
+#### Required workflow parameters:
+Parameter|Value|Description
+---|---|---
+`inputBamFile`|File|Input BAM file with aligned RNAseq reads.
+`outputFileNamePrefix`|String|Output prefix, customizable. Default is the input file's basename.
+`reference`|String|Name and version of reference genome
+
+
+#### Optional workflow parameters:
+Parameter|Value|Default|Description
+---|---|---|---
+
+
+#### Optional task parameters:
+Parameter|Value|Default|Description
+---|---|---|---
+`runACE.binsizes`|String|"c(100, 1000)"|The vector of disired bin sizes for bam files
+`runACE.ploidies`|String|"c(2,4)"|Specifies for which ploidies fits will be made
+`runACE.imagetype`|String|"png"|The image file type to create
+`runACE.method`|String|"RMSE"|A standard method for error calculation, default is the root mean squared error (RMSE)
+`runACE.penalty`|String|0|Penalty for the error calculated at lower cellularity
+`runACE.trncname`|String|"FALSE"| Whether truncate name, which truncates the name to everything before the first instance of _
+`runACE.printsummaries`|String|"TRUE"|super big summary files may crash the program, so you can set this argument to FALSE
+`runACE.timeout`|Int|8|Timeout in hours, needed to override imposed limits
+`runACE.jobMemory`|Int|24|Memory in Gb for this job
+
+
+### Outputs
+
+Output | Type | Description
+---|---|---
+`SummaryError100k2N`|File|Error lists of all the models of 100k binsize and 2N ploidy
+`SummaryError100k4N`|File|Error lists of all the models of 100k binsize and 4N ploidy
+`SummaryLikelyfits100k2N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy
+`SummaryLikelyfits100k4N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy
+`SummaryError1000k2N`|File|Error lists of all the models of 1000k binsize and 2N ploidy
+`SummaryError1000k4N`|File|Error lists of all the models of 100k binsize and 4N ploidy
+`SummaryLikelyfits1000k2N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 2N ploidy
+`SummaryLikelyfits1000k4N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 4N ploidy
+`Fitpicker100k2N`|File|Tab-delimited file used during selection of most likely models. For 100k binsize and 2N ploidy
+`Fitpicker100k4N`|File|Tab-delimited file used during selection of most likely models. For 100k binsize and 4N ploidy
+`Fitpicker1000k2N`|File|Tab-delimited file used during selection of most likely models. For 1000k binsize and 2N ploidy
+`Fitpicker1000k4N`|File|Tab-delimited file used during selection of most likely models. For 1000k binsize and 4N ploidy
+`Likelyfits100k2N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 2N ploidy
+`Likelyfits100k4N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 4N ploidy
+`Likelyfits1000k2N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 2N ploidy
+`Likelyfits1000k4N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 4N ploidy
+`SampleFolder100k2N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 2N ploidy
+`SampleFolder100k4N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 4N ploidy
+`SampleFolder1000k2N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 2N ploidy
+`SampleFolder100044N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 4N ploidy
+
+
+## Commands
+ This section lists command(s) run by WORKFLOW workflow
+ 
+ * Running WORKFLOW ACE
+
+```
+ R --no-save<<CODE
+ library(ACE)
+ library(Biobase)
+ library(QDNAseq)
+ library(QDNAseq.hg38)
+ library(QDNAseq.hg19)
+ library(ggplot2)
+ 
+ file.symlink("~{bamFile}", "./")
+ fileName = basename("~{bamFile}")
+ sampleName = tools::file_path_sans_ext(fileName)
+ 
+ runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
+ 
+ files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
+ zip(zipfile = '100k2NLikelyfits', files = files2zip)
+ files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
+ zip(zipfile = '100k4NLikelyfits', files = files2zip)
+ files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
+ zip(zipfile = '1000k2NLikelyfits', files = files2zip)
+ files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
+ zip(zipfile = '1000k4NLikelyfits', files = files2zip)
+ files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '100k2NSampleFolder', files = files2zip)
+ files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '100k4NSampleFolder', files = files2zip)
+ files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '1000k2NSampleFolder', files = files2zip)
+ files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '1000k4NSampleFolder', files = files2zip)
+ CODE
+ >>>
+ ```
+ ## Support
+
+For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
+
+_Generated with generate-markdown-readme (https://github.com/oicr-gsi/gsi-wdl-tools/)_

--- a/commands.txt
+++ b/commands.txt
@@ -1,0 +1,39 @@
+## Commands
+ This section lists command(s) run by WORKFLOW workflow
+ 
+ * Running WORKFLOW ACE
+
+```
+ R --no-save<<CODE
+ library(ACE)
+ library(Biobase)
+ library(QDNAseq)
+ library(QDNAseq.hg38)
+ library(QDNAseq.hg19)
+ library(ggplot2)
+ 
+ file.symlink("~{bamFile}", "./")
+ fileName = basename("~{bamFile}")
+ sampleName = tools::file_path_sans_ext(fileName)
+ 
+ runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
+ 
+ files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
+ zip(zipfile = '100k2NLikelyfits', files = files2zip)
+ files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
+ zip(zipfile = '100k4NLikelyfits', files = files2zip)
+ files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
+ zip(zipfile = '1000k2NLikelyfits', files = files2zip)
+ files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
+ zip(zipfile = '1000k4NLikelyfits', files = files2zip)
+ files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '100k2NSampleFolder', files = files2zip)
+ files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '100k4NSampleFolder', files = files2zip)
+ files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '1000k2NSampleFolder', files = files2zip)
+ files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
+ zip(zipfile = '1000k4NSampleFolder', files = files2zip)
+ CODE
+ >>>
+ ```


### PR DESCRIPTION
First version of ACE workflow for ticket https://jira.oicr.on.ca/browse/GRD-735
Things for considering:
1, The input currrently is single bam file. Does not use fastq and alignment and does not do merging lanes. ACE will create rds files but the wdl not provision out
2, The output files all depends on parameter options, especially bin size and ploidy, now using bin size 100k and 1000k, ploidy 2N and 4N. If all of them optional by user then all ouptputs would be optional. Currently have chosen the default.
