### PR TITLE
adjustments to output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+target/
+.idea/
+*.iml
+v.out
+vidarrtest-regression.json

--- a/ACE.wdl
+++ b/ACE.wdl
@@ -13,7 +13,6 @@ call runACE {
   input: 
   bamFile = inputBamFile,  
   modules = "ace/1.20.0",
-  aceScript = "$ACE_ROOT/share/R/ACE.R",
   genome =  reference,
   outputFileNamePrefix = outputFileNamePrefix
 }
@@ -25,9 +24,7 @@ parameter_meta {
 }
 
 output {
-  File zipFolder100k = runACE.zipFolder100k
-  File zipFolder500k = runACE.zipFolder500k
-  File zipFolder1000k = runACE.zipFolder1000k
+  File resultZip = runACE.resultZip
 }
 
 
@@ -42,9 +39,7 @@ meta {
       }
     ]
   output_meta: {
-  zipFolder100k: "Zipped folder for 100kbp bin size output",
-  zipFolder500k: "Zipped folder for 500kbp bin size output",
-  zipFolder1000k: "Zipped folder for 1000kbp bin size output"
+  resultZip: "Zipped folder for all outputs"
   }
 }
 
@@ -53,7 +48,6 @@ meta {
 task runACE {
 input {
   File bamFile
-  String aceScript
   String outputFileNamePrefix
   String genome
   String binsizes = "c(100, 500, 1000)"
@@ -70,7 +64,6 @@ input {
 
 parameter_meta {
  bamFile: "Input .bam file for analysis sample"
- aceScript: "The R script to run ACE"
  outputFileNamePrefix: "Prefix of output files"
  genome: "the genome version for bam build"
  binsizes: "The vector of disired bin sizes for bam files"
@@ -97,15 +90,11 @@ library(ggplot2)
 file.symlink("~{bamFile}", "./")
 
 
-runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
+runACE(inputdir = "./", outputdir = "./result", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
 
 
-files2zip <- dir('./500kbp', full.names = TRUE)
-zip(zipfile = paste('~{outputFileNamePrefix}','500kbp', sep='_'), files = files2zip)
-files2zip <- dir('./100kbp', full.names = TRUE)
-zip(zipfile = paste('~{outputFileNamePrefix}','100kbp', sep='_'), files = files2zip)
-files2zip <- dir('./1000kbp', full.names = TRUE)
-zip(zipfile = paste('~{outputFileNamePrefix}','1000kbp', sep='_'), files = files2zip)
+files2zip <- dir('./result', full.names = TRUE)
+zip(zipfile = paste('~{outputFileNamePrefix}','resultZip', sep='_'), files = files2zip)
 
 CODE
 >>>
@@ -117,8 +106,6 @@ runtime {
 }
 
 output {
-  File zipFolder100k = "~{outputFileNamePrefix}"+"_100kbp.zip"
-  File zipFolder500k = "~{outputFileNamePrefix}"+"_500kbp.zip"
-  File zipFolder1000k = "~{outputFileNamePrefix}"+"_1000kbp.zip"
+  File resultZip = "~{outputFileNamePrefix}"+"_resultZip.zip"
 }
 }

--- a/ACE.wdl
+++ b/ACE.wdl
@@ -25,27 +25,11 @@ parameter_meta {
 }
 
 output {
-  File SummaryError100k2N = runACE.SummaryError100k2N 
-  File SummaryError100k4N = runACE.SummaryError100k4N 
-  File SummaryLikelyfits100k2N = runACE.SummaryLikelyfits100k2N
-  File SummaryLikelyfits100k4N = runACE.SummaryLikelyfits100k4N
-  File SummaryError1000k2N = runACE.SummaryError1000k2N
-  File SummaryError1000k4N = runACE.SummaryError1000k4N
-  File SummaryLikelyfits1000k2N = runACE.SummaryLikelyfits1000k2N
-  File SummaryLikelyfits1000k4N = runACE.SummaryLikelyfits1000k4N
-  File Fitpicker100k2N = runACE.Fitpicker100k2N
-  File Fitpicker100k4N = runACE.Fitpicker100k4N
-  File Fitpicker1000k2N = runACE.Fitpicker1000k2N
-  File Fitpicker1000k4N = runACE.Fitpicker1000k4N
-  File Likelyfits100k2N = runACE.Likelyfits100k2N
-  File Likelyfits100k4N = runACE.Likelyfits100k4N
-  File Likelyfits1000k2N = runACE.Likelyfits1000k2N
-  File Likelyfits1000k4N = runACE.Likelyfits1000k4N
-  File SampleFolder100k2N = runACE.SampleFolder100k2N
-  File SampleFolder100k4N = runACE.SampleFolder100k2N
-  File SampleFolder1000k2N = runACE.SampleFolder1000k2N
-  File SampleFolder100044N = runACE.SampleFolder1000k4N
+  File zipFolder100k = runACE.zipFolder100k
+  File zipFolder500k = runACE.zipFolder500k
+  File zipFolder1000k = runACE.zipFolder1000k
 }
+
 
 meta {
   author: "Gavin Peng"
@@ -58,26 +42,9 @@ meta {
       }
     ]
   output_meta: {
-  SummaryError100k2N: "Error lists of all the models of 100k binsize and 2N ploidy",
-  SummaryError100k4N: "Error lists of all the models of 100k binsize and 4N ploidy",
-  SummaryLikelyfits100k2N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy",
-  SummaryLikelyfits100k4N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy",
-  SummaryError1000k2N: "Error lists of all the models of 1000k binsize and 2N ploidy",
-  SummaryError1000k4N: "Error lists of all the models of 100k binsize and 4N ploidy",
-  SummaryLikelyfits1000k2N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 2N ploidy",
-  SummaryLikelyfits1000k4N: "Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 4N ploidy",
-  Fitpicker100k2N: "Tab-delimited file used during selection of most likely models. For 100k binsize and 2N ploidy",
-  Fitpicker100k4N: "Tab-delimited file used during selection of most likely models. For 100k binsize and 4N ploidy",
-  Fitpicker1000k2N: "Tab-delimited file used during selection of most likely models. For 1000k binsize and 2N ploidy",
-  Fitpicker1000k4N: "Tab-delimited file used during selection of most likely models. For 1000k binsize and 4N ploidy",
-  Likelyfits100k2N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 2N ploidy",
-  Likelyfits100k4N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 4N ploidy",
-  Likelyfits1000k2N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 2N ploidy",
-  Likelyfits1000k4N: "Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 4N ploidy",
-  SampleFolder100k2N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 2N ploidy",
-  SampleFolder100k4N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 4N ploidy",
-  SampleFolder1000k2N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 2N ploidy",
-  SampleFolder100044N: "Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 4N ploidy"
+  zipFolder100k: "Zipped folder for 100kbp bin size output",
+  zipFolder500k: "Zipped folder for 500kbp bin size output",
+  zipFolder1000k: "Zipped folder for 1000kbp bin size output"
   }
 }
 
@@ -89,11 +56,11 @@ input {
   String aceScript
   String outputFileNamePrefix
   String genome
-  String binsizes = "c(100, 1000)"
-  String ploidies = "c(2,4)"
+  String binsizes = "c(30, 50, 100, 500, 1000)"
+  String ploidies = "c(2,3,4)"
   String imagetype = "png"
   String method = "RMSE"
-  String penalty = 0
+  String penalty = 0.1
   String trncname = "FALSE"
   String printsummaries = "TRUE"
   String modules
@@ -128,27 +95,18 @@ library(QDNAseq.hg19)
 library(ggplot2)
 
 file.symlink("~{bamFile}", "./")
-fileName = basename("~{bamFile}")
-sampleName = tools::file_path_sans_ext(fileName)
+
 
 runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
 
-files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
-zip(zipfile = '100k2NLikelyfits', files = files2zip)
-files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
-zip(zipfile = '100k4NLikelyfits', files = files2zip)
-files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
-zip(zipfile = '1000k2NLikelyfits', files = files2zip)
-files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
-zip(zipfile = '1000k4NLikelyfits', files = files2zip)
-files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
-zip(zipfile = '100k2NSampleFolder', files = files2zip)
-files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
-zip(zipfile = '100k4NSampleFolder', files = files2zip)
-files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
-zip(zipfile = '1000k2NSampleFolder', files = files2zip)
-files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
-zip(zipfile = '1000k4NSampleFolder', files = files2zip)
+
+files2zip <- dir('./500kbp', full.names = TRUE)
+zip(zipfile = paste('~{outputFileNamePrefix}','500kbp', sep='_'), files = files2zip)
+files2zip <- dir('./100kbp', full.names = TRUE)
+zip(zipfile = paste('~{outputFileNamePrefix}','100kbp', sep='_'), files = files2zip)
+files2zip <- dir('./1000kbp', full.names = TRUE)
+zip(zipfile = paste('~{outputFileNamePrefix}','1000kbp', sep='_'), files = files2zip)
+
 CODE
 >>>
 
@@ -159,25 +117,8 @@ runtime {
 }
 
 output {
-  File SummaryError100k2N = "./100kbp/2N/summary_errors.png"
-  File SummaryLikelyfits100k2N = "./100kbp/2N/summary_likelyfits.png"
-  File SummaryError100k4N = "./100kbp/4N/summary_errors.png"
-  File SummaryLikelyfits100k4N = "./100kbp/4N/summary_likelyfits.png"
-  File SummaryError1000k2N = "./1000kbp/2N/summary_errors.png"
-  File SummaryLikelyfits1000k2N = "./1000kbp/2N/summary_likelyfits.png"
-  File SummaryError1000k4N = "./1000kbp/4N/summary_errors.png"
-  File SummaryLikelyfits1000k4N = "./1000kbp/4N/summary_likelyfits.png"
-  File Fitpicker100k2N = "100kbp/2N/fitpicker_2N.tsv"
-  File Fitpicker100k4N = "100kbp/4N/fitpicker_4N.tsv"
-  File Fitpicker1000k2N = "1000kbp/2N/fitpicker_2N.tsv"
-  File Fitpicker1000k4N = "1000kbp/4N/fitpicker_4N.tsv"
-  File Likelyfits100k2N = "./100k2NLikelyfits.zip"
-  File Likelyfits100k4N = "./100k4NLikelyfits.zip"
-  File Likelyfits1000k2N = "./1000k2NLikelyfits.zip"
-  File Likelyfits1000k4N = "./1000k4NLikelyfits.zip"
-  File SampleFolder100k2N = "./100k2NSampleFolder.zip"
-  File SampleFolder100k4N = "./100k4NSampleFolder.zip"
-  File SampleFolder1000k2N = "./1000k2NSampleFolder.zip"
-  File SampleFolder1000k4N = "./1000k4NSampleFolder.zip"
+  File zipFolder100k = "~{outputFileNamePrefix}"+"_100kbp.zip"
+  File zipFolder500k = "~{outputFileNamePrefix}"+"_500kbp.zip"
+  File zipFolder1000k = "~{outputFileNamePrefix}"+"_1000kbp.zip"
 }
 }

--- a/ACE.wdl
+++ b/ACE.wdl
@@ -56,9 +56,9 @@ input {
   String aceScript
   String outputFileNamePrefix
   String genome
-  String binsizes = "c(30, 50, 100, 500, 1000)"
+  String binsizes = "c(100, 500, 1000)"
   String ploidies = "c(2,3,4)"
-  String imagetype = "png"
+  String imagetype = "pdf"
   String method = "RMSE"
   String penalty = 0.1
   String trncname = "FALSE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.0   - 2024-01-29
+- [GRD-735] Initial version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,23 @@
+pipeline {
+  agent any
+  stages {
+    stage('build') {
+      when {
+        not {
+          buildingTag()
+        }
+      }
+      steps {
+        sh '/.mounts/labs/gsi/vidarr/jenkins-ci-wrapper test -t /.mounts/labs/gsi/vidarr/testing-config.json'
+      }
+    }
+    stage('Deploy') {
+      when {
+        buildingTag()
+      }
+      steps {
+        sh '/.mounts/labs/gsi/vidarr/jenkins-ci-wrapper deploy -v $TAG_NAME -t /.mounts/labs/gsi/vidarr/testing-config.json -U /.mounts/labs/gsi/vidarr/deploy-urls'
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,50 @@
 ACE, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data
 
 ## Overview
+ACE is a an absolute copy number estimator that scales copy number data to fit with integer copy numbers.
+For this it uses segmented data from the QDNAseq package, which in turn uses a number of dependencies.
+Note: make sure QDNAseq fetches the bin annotations from the same genome build as the one used for
+aligning the sequencing data!
+
+In brief: ACE will run QDNAseq or use its output rds-file(s)
+of segmented data. It will subsequently run through all samples in the object(s), for which it will create
+individual subdirectories. For each sample, it will calculate how well the segments fit (the relative error)
+to integer copy numbers for each percentage of “tumor cells” (cells with divergent segments). Note that it
+does not estimate for a lower percentage than 5. ACE will output a graph with relative errors (all errors
+relative to the largest error). Said graph can be used to quickly identify the most likely fit. ACE selects all
+“minima” and saves the corresponding copy number plots. The “best fit” (lowest error) is not by definition
+the most likely fit! ACE will run models for a general tumor ploidy of 2N, but you can expand this to include
+any ploidy of your choosing. The program needs to make one assumption: the median bin segment value
+corresponds with the tumor’s general ploidy.
+
+### ACE output
+**rds-file**
+This is the segmented QDNAseq object; obviously not created when using rds-file as input. It can be used if
+you want to run ACE again with slightly different parameters. More importantly, you can use this file to
+examine individual samples in downstream analyses.
+
+**rds subdirectories**
+ACE creates a subdirectory for each rds-file. In case of bam-files as input, the subdirectories have the names
+of the binsizes.
+
+**ploidies subdirectories**
+For each analyzed tumor ploidy, ACE makes a subdirectory. In this case: 2N and 4N
+
+**summaries**
+summary_errors: error lists of all the models summary_likelyfits: copy number plots of the best fit and the
+last minimum of each sample, with the corresponding error list plots. I would recommend using the likelyfits
+for model selection. Summary files can become quite big / huge depending on sample size and bin size. See
+below how to deal with this.
+
+**likelyfits subdirectory**
+This subdirectory contains the individual copy number graphs of the likelyfits.
+2individual sample subdirectories
+These subdirectories have a summary file with all the fits for the corresponding sample and the error list plot.
+Individual copy number graphs are available in the subdirectory “graphs”.
+
+**fitpicker tables**
+This tab-delimited file can be used during selection of most likely models. Especially handy when analyzing a
+large number of samples. 
 
 ## Dependencies
 
@@ -34,9 +78,9 @@ Parameter|Value|Default|Description
 #### Optional task parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
-`runACE.binsizes`|String|"c(30, 50, 100, 500, 1000)"|The vector of disired bin sizes for bam files
+`runACE.binsizes`|String|"c(100, 500, 1000)"|The vector of disired bin sizes for bam files
 `runACE.ploidies`|String|"c(2,3,4)"|Specifies for which ploidies fits will be made
-`runACE.imagetype`|String|"png"|The image file type to create
+`runACE.imagetype`|String|"pdf"|The image file type to create
 `runACE.method`|String|"RMSE"|A standard method for error calculation, default is the root mean squared error (RMSE)
 `runACE.penalty`|String|0.1|Penalty for the error calculated at lower cellularity
 `runACE.trncname`|String|"FALSE"| Whether truncate name, which truncates the name to everything before the first instance of _
@@ -49,50 +93,35 @@ Parameter|Value|Default|Description
 
 Output | Type | Description
 ---|---|---
-`zipFolder100k`|File|Zipped folder for 100kbp bin size output
-`zipFolder500k`|File|Zipped folder for 500kbp bin size output
-`zipFolder1000k`|File|Zipped folder for 1000kbp bin size output
+`resultZip`|File|Zipped folder for all outputs
 
 
 ## Commands
-  This section lists command(s) run by WORKFLOW workflow
-  
-  * Running WORKFLOW ACE
+ This section lists command(s) run by ACE workflow
+ 
+ * Running ACE
  
  ```
-  R --no-save<<CODE
-  library(ACE)
-  library(Biobase)
-  library(QDNAseq)
-  library(QDNAseq.hg38)
-  library(QDNAseq.hg19)
-  library(ggplot2)
-  
-  file.symlink("~{bamFile}", "./")
-  fileName = basename("~{bamFile}")
-  sampleName = tools::file_path_sans_ext(fileName)
-  
-  runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
-  
-  files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
-  zip(zipfile = '100k2NLikelyfits', files = files2zip)
-  files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
-  zip(zipfile = '100k4NLikelyfits', files = files2zip)
-  files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
-  zip(zipfile = '1000k2NLikelyfits', files = files2zip)
-  files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
-  zip(zipfile = '1000k4NLikelyfits', files = files2zip)
-  files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '100k2NSampleFolder', files = files2zip)
-  files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '100k4NSampleFolder', files = files2zip)
-  files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '1000k2NSampleFolder', files = files2zip)
-  files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '1000k4NSampleFolder', files = files2zip)
-  CODE
-  >>>
-  ``` ## Support
+ R --no-save<<CODE
+ library(ACE)
+ library(Biobase)
+ library(QDNAseq)
+ library(QDNAseq.hg38)
+ library(QDNAseq.hg19)
+ library(ggplot2)
+ 
+ file.symlink("~{bamFile}", "./")
+ 
+ 
+ runACE(inputdir = "./", outputdir = "./result", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
+ 
+ 
+ files2zip <- dir('./result', full.names = TRUE)
+ zip(zipfile = paste('~{outputFileNamePrefix}','resultZip', sep='_'), files = files2zip)
+ 
+ CODE
+ ```
+ ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Parameter|Value|Default|Description
 #### Optional task parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
-`runACE.binsizes`|String|"c(100, 1000)"|The vector of disired bin sizes for bam files
-`runACE.ploidies`|String|"c(2,4)"|Specifies for which ploidies fits will be made
+`runACE.binsizes`|String|"c(30, 50, 100, 500, 1000)"|The vector of disired bin sizes for bam files
+`runACE.ploidies`|String|"c(2,3,4)"|Specifies for which ploidies fits will be made
 `runACE.imagetype`|String|"png"|The image file type to create
 `runACE.method`|String|"RMSE"|A standard method for error calculation, default is the root mean squared error (RMSE)
-`runACE.penalty`|String|0|Penalty for the error calculated at lower cellularity
+`runACE.penalty`|String|0.1|Penalty for the error calculated at lower cellularity
 `runACE.trncname`|String|"FALSE"| Whether truncate name, which truncates the name to everything before the first instance of _
 `runACE.printsummaries`|String|"TRUE"|super big summary files may crash the program, so you can set this argument to FALSE
 `runACE.timeout`|Int|8|Timeout in hours, needed to override imposed limits
@@ -49,68 +49,50 @@ Parameter|Value|Default|Description
 
 Output | Type | Description
 ---|---|---
-`SummaryError100k2N`|File|Error lists of all the models of 100k binsize and 2N ploidy
-`SummaryError100k4N`|File|Error lists of all the models of 100k binsize and 4N ploidy
-`SummaryLikelyfits100k2N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy
-`SummaryLikelyfits100k4N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 100k binsize and 2N ploidy
-`SummaryError1000k2N`|File|Error lists of all the models of 1000k binsize and 2N ploidy
-`SummaryError1000k4N`|File|Error lists of all the models of 100k binsize and 4N ploidy
-`SummaryLikelyfits1000k2N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 2N ploidy
-`SummaryLikelyfits1000k4N`|File|Copy number plots of the best fit and the last minimum of each sample, with the corresponding error list plots. For 1000k binsize and 4N ploidy
-`Fitpicker100k2N`|File|Tab-delimited file used during selection of most likely models. For 100k binsize and 2N ploidy
-`Fitpicker100k4N`|File|Tab-delimited file used during selection of most likely models. For 100k binsize and 4N ploidy
-`Fitpicker1000k2N`|File|Tab-delimited file used during selection of most likely models. For 1000k binsize and 2N ploidy
-`Fitpicker1000k4N`|File|Tab-delimited file used during selection of most likely models. For 1000k binsize and 4N ploidy
-`Likelyfits100k2N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 2N ploidy
-`Likelyfits100k4N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 100k binsize and 4N ploidy
-`Likelyfits1000k2N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 2N ploidy
-`Likelyfits1000k4N`|File|Zip of subdirectory contains the individual copy number graphs of the likelyfits. For 1000k binsize and 4N ploidy
-`SampleFolder100k2N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 2N ploidy
-`SampleFolder100k4N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 100k binsize and 4N ploidy
-`SampleFolder1000k2N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 2N ploidy
-`SampleFolder100044N`|File|Zip file of individual sample subdirectories, have a summary file with all the fits for the corresponding sample and the error list plot. Individual copy number graphs are available in the subdirectory 'graphs'. For 1000k binsize and 4N ploidy
+`zipFolder100k`|File|Zipped folder for 100kbp bin size output
+`zipFolder500k`|File|Zipped folder for 500kbp bin size output
+`zipFolder1000k`|File|Zipped folder for 1000kbp bin size output
 
 
 ## Commands
- This section lists command(s) run by WORKFLOW workflow
+  This section lists command(s) run by WORKFLOW workflow
+  
+  * Running WORKFLOW ACE
  
- * Running WORKFLOW ACE
-
-```
- R --no-save<<CODE
- library(ACE)
- library(Biobase)
- library(QDNAseq)
- library(QDNAseq.hg38)
- library(QDNAseq.hg19)
- library(ggplot2)
- 
- file.symlink("~{bamFile}", "./")
- fileName = basename("~{bamFile}")
- sampleName = tools::file_path_sans_ext(fileName)
- 
- runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
- 
- files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
- zip(zipfile = '100k2NLikelyfits', files = files2zip)
- files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
- zip(zipfile = '100k4NLikelyfits', files = files2zip)
- files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
- zip(zipfile = '1000k2NLikelyfits', files = files2zip)
- files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
- zip(zipfile = '1000k4NLikelyfits', files = files2zip)
- files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '100k2NSampleFolder', files = files2zip)
- files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '100k4NSampleFolder', files = files2zip)
- files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '1000k2NSampleFolder', files = files2zip)
- files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '1000k4NSampleFolder', files = files2zip)
- CODE
- >>>
  ```
- ## Support
+  R --no-save<<CODE
+  library(ACE)
+  library(Biobase)
+  library(QDNAseq)
+  library(QDNAseq.hg38)
+  library(QDNAseq.hg19)
+  library(ggplot2)
+  
+  file.symlink("~{bamFile}", "./")
+  fileName = basename("~{bamFile}")
+  sampleName = tools::file_path_sans_ext(fileName)
+  
+  runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
+  
+  files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
+  zip(zipfile = '100k2NLikelyfits', files = files2zip)
+  files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
+  zip(zipfile = '100k4NLikelyfits', files = files2zip)
+  files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
+  zip(zipfile = '1000k2NLikelyfits', files = files2zip)
+  files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
+  zip(zipfile = '1000k4NLikelyfits', files = files2zip)
+  files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '100k2NSampleFolder', files = files2zip)
+  files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '100k4NSampleFolder', files = files2zip)
+  files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '1000k2NSampleFolder', files = files2zip)
+  files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '1000k4NSampleFolder', files = files2zip)
+  CODE
+  >>>
+  ``` ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,8 @@
-# ACE
+# ace
 
-ACE, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data
+ace, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data
 
 ## Overview
-ACE is a an absolute copy number estimator that scales copy number data to fit with integer copy numbers.
-For this it uses segmented data from the QDNAseq package, which in turn uses a number of dependencies.
-Note: make sure QDNAseq fetches the bin annotations from the same genome build as the one used for
-aligning the sequencing data!
-
-In brief: ACE will run QDNAseq or use its output rds-file(s)
-of segmented data. It will subsequently run through all samples in the object(s), for which it will create
-individual subdirectories. For each sample, it will calculate how well the segments fit (the relative error)
-to integer copy numbers for each percentage of “tumor cells” (cells with divergent segments). Note that it
-does not estimate for a lower percentage than 5. ACE will output a graph with relative errors (all errors
-relative to the largest error). Said graph can be used to quickly identify the most likely fit. ACE selects all
-“minima” and saves the corresponding copy number plots. The “best fit” (lowest error) is not by definition
-the most likely fit! ACE will run models for a general tumor ploidy of 2N, but you can expand this to include
-any ploidy of your choosing. The program needs to make one assumption: the median bin segment value
-corresponds with the tumor’s general ploidy.
-
-### ACE output
-**rds-file**
-This is the segmented QDNAseq object; obviously not created when using rds-file as input. It can be used if
-you want to run ACE again with slightly different parameters. More importantly, you can use this file to
-examine individual samples in downstream analyses.
-
-**rds subdirectories**
-ACE creates a subdirectory for each rds-file. In case of bam-files as input, the subdirectories have the names
-of the binsizes.
-
-**ploidies subdirectories**
-For each analyzed tumor ploidy, ACE makes a subdirectory. In this case: 2N and 4N
-
-**summaries**
-summary_errors: error lists of all the models summary_likelyfits: copy number plots of the best fit and the
-last minimum of each sample, with the corresponding error list plots. I would recommend using the likelyfits
-for model selection. Summary files can become quite big / huge depending on sample size and bin size. See
-below how to deal with this.
-
-**likelyfits subdirectory**
-This subdirectory contains the individual copy number graphs of the likelyfits.
-2individual sample subdirectories
-These subdirectories have a summary file with all the fits for the corresponding sample and the error list plot.
-Individual copy number graphs are available in the subdirectory “graphs”.
-
-**fitpicker tables**
-This tab-delimited file can be used during selection of most likely models. Especially handy when analyzing a
-large number of samples. 
 
 ## Dependencies
 
@@ -57,7 +13,7 @@ large number of samples.
 
 ### Cromwell
 ```
-java -jar cromwell.jar run ACE.wdl --inputs inputs.json
+java -jar cromwell.jar run ace.wdl --inputs inputs.json
 ```
 
 ### Inputs
@@ -78,15 +34,15 @@ Parameter|Value|Default|Description
 #### Optional task parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
-`runACE.binsizes`|String|"c(100, 500, 1000)"|The vector of disired bin sizes for bam files
-`runACE.ploidies`|String|"c(2,3,4)"|Specifies for which ploidies fits will be made
-`runACE.imagetype`|String|"pdf"|The image file type to create
-`runACE.method`|String|"RMSE"|A standard method for error calculation, default is the root mean squared error (RMSE)
-`runACE.penalty`|String|0.1|Penalty for the error calculated at lower cellularity
-`runACE.trncname`|String|"FALSE"| Whether truncate name, which truncates the name to everything before the first instance of _
-`runACE.printsummaries`|String|"TRUE"|super big summary files may crash the program, so you can set this argument to FALSE
-`runACE.timeout`|Int|8|Timeout in hours, needed to override imposed limits
-`runACE.jobMemory`|Int|24|Memory in Gb for this job
+`runAce.binsizes`|String|"c(100, 500, 1000)"|The vector of disired bin sizes for bam files
+`runAce.ploidies`|String|"c(2,3,4)"|Specifies for which ploidies fits will be made
+`runAce.imagetype`|String|"pdf"|The image file type to create
+`runAce.method`|String|"RMSE"|A standard method for error calculation, default is the root mean squared error (RMSE)
+`runAce.penalty`|String|0.1|Penalty for the error calculated at lower cellularity
+`runAce.trncname`|String|"FALSE"| Whether truncate name, which truncates the name to everything before the first instance of _
+`runAce.printsummaries`|String|"TRUE"|super big summary files may crash the program, so you can set this argument to FALSE
+`runAce.timeout`|Int|8|Timeout in hours, needed to override imposed limits
+`runAce.jobMemory`|Int|24|Memory in Gb for this job
 
 
 ### Outputs
@@ -97,9 +53,9 @@ Output | Type | Description
 
 
 ## Commands
- This section lists command(s) run by ACE workflow
+ This section lists command(s) run by ace workflow
  
- * Running ACE
+ * Running ace
  
  ```
  R --no-save<<CODE

--- a/ace.wdl
+++ b/ace.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 
-workflow ACE {
+workflow ace {
 input {
   File inputBamFile
   String outputFileNamePrefix
@@ -9,7 +9,7 @@ input {
 }
 
 
-call runACE { 
+call runAce { 
   input: 
   bamFile = inputBamFile,  
   modules = "ace/1.20.0",
@@ -24,14 +24,14 @@ parameter_meta {
 }
 
 output {
-  File resultZip = runACE.resultZip
+  File resultZip = runAce.resultZip
 }
 
 
 meta {
   author: "Gavin Peng"
   email: "gpeng@oicr.on.ca"
-  description: "ACE, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data"
+  description: "ace, workflow for absolute copy number estimation from low-coverage whole-genome sequencing data"
   dependencies: [
       {
         name: "ace/1.20.0",
@@ -45,7 +45,7 @@ meta {
 
 }
 
-task runACE {
+task runAce {
 input {
   File bamFile
   String outputFileNamePrefix

--- a/commands.txt
+++ b/commands.txt
@@ -1,39 +1,25 @@
 ## Commands
-  This section lists command(s) run by WORKFLOW workflow
-  
-  * Running WORKFLOW ACE
- 
- ```
-  R --no-save<<CODE
-  library(ACE)
-  library(Biobase)
-  library(QDNAseq)
-  library(QDNAseq.hg38)
-  library(QDNAseq.hg19)
-  library(ggplot2)
-  
-  file.symlink("~{bamFile}", "./")
-  fileName = basename("~{bamFile}")
-  sampleName = tools::file_path_sans_ext(fileName)
-  
-  runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
-  
-  files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
-  zip(zipfile = '100k2NLikelyfits', files = files2zip)
-  files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
-  zip(zipfile = '100k4NLikelyfits', files = files2zip)
-  files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
-  zip(zipfile = '1000k2NLikelyfits', files = files2zip)
-  files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
-  zip(zipfile = '1000k4NLikelyfits', files = files2zip)
-  files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '100k2NSampleFolder', files = files2zip)
-  files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '100k4NSampleFolder', files = files2zip)
-  files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '1000k2NSampleFolder', files = files2zip)
-  files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
-  zip(zipfile = '1000k4NSampleFolder', files = files2zip)
-  CODE
-  >>>
-  ```
+This section lists command(s) run by ACE workflow
+
+* Running ACE
+
+```
+R --no-save<<CODE
+library(ACE)
+library(Biobase)
+library(QDNAseq)
+library(QDNAseq.hg38)
+library(QDNAseq.hg19)
+library(ggplot2)
+
+file.symlink("~{bamFile}", "./")
+
+
+runACE(inputdir = "./", outputdir = "./result", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
+
+
+files2zip <- dir('./result', full.names = TRUE)
+zip(zipfile = paste('~{outputFileNamePrefix}','resultZip', sep='_'), files = files2zip)
+
+CODE
+```

--- a/commands.txt
+++ b/commands.txt
@@ -1,39 +1,39 @@
 ## Commands
- This section lists command(s) run by WORKFLOW workflow
+  This section lists command(s) run by WORKFLOW workflow
+  
+  * Running WORKFLOW ACE
  
- * Running WORKFLOW ACE
-
-```
- R --no-save<<CODE
- library(ACE)
- library(Biobase)
- library(QDNAseq)
- library(QDNAseq.hg38)
- library(QDNAseq.hg19)
- library(ggplot2)
- 
- file.symlink("~{bamFile}", "./")
- fileName = basename("~{bamFile}")
- sampleName = tools::file_path_sans_ext(fileName)
- 
- runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
- 
- files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
- zip(zipfile = '100k2NLikelyfits', files = files2zip)
- files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
- zip(zipfile = '100k4NLikelyfits', files = files2zip)
- files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
- zip(zipfile = '1000k2NLikelyfits', files = files2zip)
- files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
- zip(zipfile = '1000k4NLikelyfits', files = files2zip)
- files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '100k2NSampleFolder', files = files2zip)
- files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '100k4NSampleFolder', files = files2zip)
- files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '1000k2NSampleFolder', files = files2zip)
- files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
- zip(zipfile = '1000k4NSampleFolder', files = files2zip)
- CODE
- >>>
  ```
+  R --no-save<<CODE
+  library(ACE)
+  library(Biobase)
+  library(QDNAseq)
+  library(QDNAseq.hg38)
+  library(QDNAseq.hg19)
+  library(ggplot2)
+  
+  file.symlink("~{bamFile}", "./")
+  fileName = basename("~{bamFile}")
+  sampleName = tools::file_path_sans_ext(fileName)
+  
+  runACE(inputdir = "./", outputdir = "./", filetype='bam', genome = "~{genome}", binsizes = ~{binsizes}, ploidies = ~{ploidies}, imagetype= "~{imagetype}", method = "~{method}", penalty = ~{penalty}, trncname = ~{trncname}, printsummaries = ~{printsummaries}) 
+  
+  files2zip <- dir('100kbp/2N/likelyfits', full.names = TRUE)
+  zip(zipfile = '100k2NLikelyfits', files = files2zip)
+  files2zip <- dir('100kbp/4N/likelyfits', full.names = TRUE)
+  zip(zipfile = '100k4NLikelyfits', files = files2zip)
+  files2zip <- dir('1000kbp/2N/likelyfits', full.names = TRUE)
+  zip(zipfile = '1000k2NLikelyfits', files = files2zip)
+  files2zip <- dir('1000kbp/4N/likelyfits', full.names = TRUE)
+  zip(zipfile = '1000k4NLikelyfits', files = files2zip)
+  files2zip <- dir(paste('100kbp/2N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '100k2NSampleFolder', files = files2zip)
+  files2zip <- dir(paste('100kbp/4N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '100k4NSampleFolder', files = files2zip)
+  files2zip <- dir(paste('1000kbp/2N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '1000k2NSampleFolder', files = files2zip)
+  files2zip <- dir(paste('1000kbp/4N/', sampleName, sep=''), full.names = TRUE)
+  zip(zipfile = '1000k4NSampleFolder', files = files2zip)
+  CODE
+  >>>
+  ```

--- a/commands.txt
+++ b/commands.txt
@@ -1,7 +1,7 @@
 ## Commands
-This section lists command(s) run by ACE workflow
+This section lists command(s) run by ace workflow
 
-* Running ACE
+* Running ace
 
 ```
 R --no-save<<CODE

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 cd $1
-md5sum TGL48_0001_Ct_T_PE_312_WG_resultZip.zip
+find . -xtype f 

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $1
+md5sum TGL48_0001_Ct_T_PE_312_WG_resultZip.zip

--- a/tests/compare.sh
+++ b/tests/compare.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+diff -b  $1 $2

--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,0 +1,6 @@
+{
+    "names": [
+        "ace"
+    ],
+    "wdl": "ace.wdl"
+}

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -1,0 +1,42 @@
+[
+    {
+        "arguments": {
+            "ace.runAce.imagetype": "pdf",
+            "ace.inputBamFile": "/.mounts/labs/gsi/testdata/ichorCNA/input_data/TGL48_0001_Ct_T_PE_312_WG_UMB-001-6M-P_INPUT_201130_NB551051_0196_AH3GGWBGXH_1_CTTGTCGA-CGATGTTC.bam",
+            "ace.runAce.penalty": "0.1",
+            "ace.outputFileNamePrefix": "TGL48_0001_Ct_T_PE_312_WG",
+            "ace.reference": "hg38",
+            "ace.runAce.jobMemory": 24,
+            "ace.runAce.ploidies": "c(2,3,4)",
+            "ace.runAce.printsummaries": "TRUE",
+            "ace.runAce.timeout": 8,
+            "ace.runAce.method": "RMSE",
+            "ace.runAce.trncname": "FALSE",
+            "ace.runAce.binsizes": "c(100, 500, 1000)"
+        },
+        "description": "ace workflow test",
+        "engineArguments": {
+           "write_to_cache": false,
+           "read_from_cache": false
+        },
+        "id": "ace_test_with_TGL48",
+        "metadata": {
+            "ace.resultZip": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ace_test_with_TGL48_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/ace/output_expectation/ace_test_with_TGL48.metrics",
+                "type": "script"
+            }
+        ]
+    }
+]

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -2,7 +2,18 @@
     {
         "arguments": {
             "ace.runAce.imagetype": "pdf",
-            "ace.inputBamFile": "/.mounts/labs/gsi/testdata/ichorCNA/input_data/TGL48_0001_Ct_T_PE_312_WG_UMB-001-6M-P_INPUT_201130_NB551051_0196_AH3GGWBGXH_1_CTTGTCGA-CGATGTTC.bam",
+            "ace.inputBamFile": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/ichorCNA/input_data/TGL48_0001_Ct_T_PE_312_WG_UMB-001-6M-P_INPUT_201130_NB551051_0196_AH3GGWBGXH_1_CTTGTCGA-CGATGTTC.bam",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
             "ace.runAce.penalty": "0.1",
             "ace.outputFileNamePrefix": "TGL48_0001_Ct_T_PE_312_WG",
             "ace.reference": "hg38",


### PR DESCRIPTION
1, ACE will generate a lot of files mostly plots, so changed to zip the folders as outputs. 
   Some of the plots looks reduntant for some runs, but some times there will be different fits of model generated, so better keep all the files
2, Tried to use more bin sizes, but looking at the results, the smaller size often too sensitive to noise, and generate results very different from the larger bin size results. As author suggeted big bin size, now only keep 100k,500k, and 1000k bin sizes
3, ACE author aiming at the user to perform more manual analysis as automatically generated plots may not be the best model, for our pipeline we can only provide as much model as neccessary for user to choose but let user decide if need to more manual analysis.
4, Some documents of ACE under directory  /.mounts/labs/gsiprojects/gsi/Investigations/GRD-735_ACE_Review, and results of comparing to ichorCNA are under "ichorCNA_compare" subdirectory. General observation of the compare is for large bin size often the tumor fraction numers are close to ichorCNA number, but for poidy ACE only fit for interger 2N,3N,4N..., and user needs to choose for the best fit poidy model.